### PR TITLE
fix: 修复中文搜索关键词导致的ASCII编码错误

### DIFF
--- a/boss_cli/client.py
+++ b/boss_cli/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import random
 import time
+import urllib.parse
 from collections import deque
 from typing import Any
 
@@ -158,7 +159,7 @@ class BossClient:
         if url == JOB_SEARCH_URL:
             query = ""
             if params and params.get("query"):
-                query = f"?query={params['query']}"
+                query = f"?query={urllib.parse.quote(params['query'])}"
             headers["Referer"] = f"{WEB_GEEK_JOB_URL}{query}"
         elif url == GEEK_GET_JOB_URL and params and params.get("tag") == 5:
             headers["Referer"] = WEB_GEEK_RECOMMEND_URL


### PR DESCRIPTION
## 修复内容

修复中文搜索关键词导致的ASCII编码错误问题：

- 问题：搜索包含中文的关键词时，HTTP Referer头直接拼接中文导致`UnicodeEncodeError: 'ascii' codec can't encode characters`错误
- 解决方案：导入`urllib.parse`对搜索关键词进行URL编码后再拼接到Referer头
- 验证：已测试中文关键词搜索功能正常，可正常返回搜索结果