### PR TITLE
feat: add job URL support in cache and CSV export

### DIFF
--- a/boss_cli/commands/search.py
+++ b/boss_cli/commands/search.py
@@ -327,10 +327,12 @@ def export(
         else:
             # CSV
             buf = io.StringIO()
-            fieldnames = ["职位", "公司", "薪资", "经验", "学历", "城市", "地区", "技能", "securityId"]
+            fieldnames = ["职位", "公司", "薪资", "经验", "学历", "城市", "地区", "技能", "URL", "securityId"]
             writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
             writer.writeheader()
             for job in all_jobs:
+                eid = job.get("encryptJobId", "")
+                url = f"https://www.zhipin.com/job_detail/{eid}.html" if eid else ""
                 writer.writerow({
                     "职位": job.get("jobName", ""),
                     "公司": job.get("brandName", ""),
@@ -340,6 +342,7 @@ def export(
                     "城市": job.get("cityName", ""),
                     "地区": job.get("areaDistrict", ""),
                     "技能": ", ".join(job.get("skills", [])),
+                    "URL": url,
                     "securityId": job.get("securityId", ""),
                 })
             output_text = buf.getvalue()

--- a/boss_cli/index_cache.py
+++ b/boss_cli/index_cache.py
@@ -35,6 +35,7 @@ def save_index(jobs: list[dict[str, Any]], source: str = "search") -> None:
     for job in jobs:
         entry = {
             "securityId": job.get("securityId", ""),
+            "encryptJobId": job.get("encryptJobId", ""),
             "jobName": job.get("jobName", ""),
             "brandName": job.get("brandName", ""),
             "salaryDesc": job.get("salaryDesc", ""),


### PR DESCRIPTION
## What

Persist \encryptJobId\ in search result cache and add a URL column to CSV export, enabling easy integration with external tools.

## Changes

### index_cache.py
- Add \encryptJobId\ field to cached job entries
- URL format: \https://www.zhipin.com/job_detail/{encryptJobId}.html\`n
### commands/search.py
- Add \URL\ column to CSV export output

## Why

Boss-cli is great for searching and greeting, but users often want to manage job data externally (Notion, spreadsheets, databases). Having direct URLs makes it much easier to:
- Click through to view full job details in browser
- Build tracking workflows with tools like Notion MCP
- Share specific job listings

## Verified

Tested on Windows 11 — exported URLs correctly open the corresponding job detail pages on zhipin.com.